### PR TITLE
Add timezone info in heartbeat payload

### DIFF
--- a/Runtime/Heartbeat/Extensions.cs
+++ b/Runtime/Heartbeat/Extensions.cs
@@ -44,8 +44,17 @@ namespace Heimo.AuraSync.Heartbeat
         
         public static string ToIso8601String(this DateTime dateTime)
         {
-            return dateTime.ToString("yyyy-MM-ddTHH:mm:ssZ");
-        }  
+            return dateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
+        }
+
+        /// <summary>
+        /// Retorna o offset de fuso horário local no formato "+HH:mm" ou "-HH:mm".
+        /// </summary>
+        public static string GetTimeZoneOffsetString()
+        {
+            TimeSpan offset = TimeZoneInfo.Local.GetUtcOffset(DateTime.Now);
+            return (offset < TimeSpan.Zero ? "-" : "+") + offset.ToString(@"hh\:mm");
+        }
     }
 }
 

--- a/Runtime/Heartbeat/Heartbeat.cs
+++ b/Runtime/Heartbeat/Heartbeat.cs
@@ -31,6 +31,7 @@ namespace Heimo.AuraSync.Heartbeat
         public string UnityVersion { get; set; } // Versão completa do Unity Editor
         public string OSPlatform { get; set; } // Plataforma do S.O. (ex: "Windows", "macOS")
         public string EventDetails { get; set; } // Ex: "Compilation started", "Package 'DOTween' imported"
+        public string TimeZoneOffset { get; set; } // Offset do fuso horário local
     }
 }
 

--- a/Runtime/Heartbeat/HeartbeatCollector.cs
+++ b/Runtime/Heartbeat/HeartbeatCollector.cs
@@ -221,7 +221,8 @@ namespace Heimo.AuraSync.Heartbeat
                 EntityType = EntityTypes.Other, // Definir um default, será refinado abaixo
                 UnityVersion = Application.unityVersion,
                 OSPlatform = SystemInfo.operatingSystem,
-                EventDetails = eventDetails
+                EventDetails = eventDetails,
+                TimeZoneOffset = DateTimeExtensions.GetTimeZoneOffsetString()
             };
 
             // Tentar determinar EntityType e EntityRelativePath e EntityFileType

--- a/Runtime/Heartbeat/HeartbeatData.cs
+++ b/Runtime/Heartbeat/HeartbeatData.cs
@@ -33,6 +33,7 @@ namespace Heimo.AuraSync.Heartbeat // Mantendo o namespace atual, ajuste se o pa
         public string unity_version; // Versão completa do Unity Editor
         public string os_platform; // Plataforma do S.O. (ex: "Windows", "macOS")
         public string event_details; // Ex: "Compilation started", "Package 'DOTween' imported"
+        public string time_zone_offset; // Offset do fuso horário local
 
         /// <summary>
         /// Converte um objeto Heartbeat interno para a estrutura serializável HeartbeatData.
@@ -59,7 +60,8 @@ namespace Heimo.AuraSync.Heartbeat // Mantendo o namespace atual, ajuste se o pa
                 selected_property_name = heartbeat.SelectedPropertyName,
                 unity_version = heartbeat.UnityVersion,
                 os_platform = heartbeat.OSPlatform,
-                event_details = heartbeat.EventDetails
+                event_details = heartbeat.EventDetails,
+                time_zone_offset = heartbeat.TimeZoneOffset
             };
         }
     }


### PR DESCRIPTION
## Summary
- ensure ISO8601 timestamps use UTC
- expose timezone offset on `Heartbeat`
- include timezone offset when creating heartbeat
- map timezone offset to the serialized payload

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_685a31f5408c8333989d23896a556070

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Heartbeat data now includes the local time zone offset, providing additional context for timestamp information.

- **Bug Fixes**
  - Improved date formatting to ensure all ISO 8601 timestamps are consistently represented in UTC.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->